### PR TITLE
php-7.4 image should have composer 2 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,4 @@ RUN sudo apt-get update && sudo apt-get install -y \
 
 RUN sudo pecl install pcov && \
     sudo sh -c 'echo "extension=pcov.so" > /etc/php/7.4/mods-available/pcov.ini' && \
-    sudo phpenmod pcov && \
-    sudo composer self-update --1
+    sudo phpenmod pcov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Equisoft php circleci image
 
-Based on cimg/php:7.2-node  https://github.com/CircleCI-Public/cimg-php
+Based on cimg/php:7.4-node  https://github.com/CircleCI-Public/cimg-php
 
 - Add pcov extension for faster test coverage
 - Add all php extensions used by equisoft
+- This image come with composer 2.0. If you need composer 1 run `sudo composer self-update --1`

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build -t kronostechnologies/php:7.2-node .
+docker build -t kronostechnologies/php:7.4-node .


### PR DESCRIPTION
L'image doit avoir composer 2 par défaut.

CRM est maintenant compatible avec composer2, je vais juste ajouter un run step temporaire pour downgrader composer sur stable/main et release/main

Voir https://github.com/kronostechnologies/circleci-orbs/pull/28